### PR TITLE
Add signal-policy architecture and RL training stage

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -30,6 +30,18 @@ class ModelConfig:
 
 
 @dataclass
+class SignalModelConfig(ModelConfig):
+    """
+    Configuration for the hybrid signal encoder that feeds the execution policy.
+    """
+
+    use_direction_head: bool = True
+    use_forecast_head: bool = True
+    forecast_output_dim: int = 1
+    signal_dropout: float = 0.1
+
+
+@dataclass
 class TrainingConfig:
     batch_size: int = 64
     epochs: int = 20
@@ -39,6 +51,35 @@ class TrainingConfig:
     grad_clip: Optional[float] = 1.0
     log_every: int = 50
     checkpoint_path: str = "models/best_model.pt"
+
+
+@dataclass
+class PolicyConfig:
+    """
+    Configuration for the PPO/A3C-style execution policy head.
+    """
+
+    input_dim: int
+    hidden_dim: int = 128
+    num_actions: int = 3
+    value_hidden_dim: Optional[int] = None
+    dropout: float = 0.1
+
+
+@dataclass
+class RLTrainingConfig:
+    """
+    Training configuration for policy optimization that consumes signal outputs.
+    """
+
+    epochs: int = 5
+    learning_rate: float = 3e-4
+    entropy_coef: float = 0.01
+    value_coef: float = 0.5
+    gamma: float = 0.99
+    grad_clip: Optional[float] = 1.0
+    detach_signal: bool = True
+    checkpoint_path: str = "models/best_policy.pt"
 
 
 @dataclass

--- a/eval/agent_eval.py
+++ b/eval/agent_eval.py
@@ -5,6 +5,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from models.agent_hybrid import HybridCNNLSTMAttention
+from models.signal_policy import SignalPolicyAgent
 
 
 def _collect_outputs(
@@ -76,3 +77,30 @@ def evaluate_model(
     if task_type == "classification":
         return classification_metrics(logits_or_preds, targets)
     return regression_metrics(logits_or_preds, targets)
+
+
+def evaluate_policy_agent(
+    agent: SignalPolicyAgent, loader: DataLoader, task_type: str = "classification"
+) -> Dict[str, float]:
+    device = next(agent.parameters()).device
+    agent.eval()
+    total = 0
+    correct = 0
+    value_sum = 0.0
+    with torch.no_grad():
+        for x, y in loader:
+            x = x.to(device)
+            y = y.to(device)
+            out = agent(x, detach_signal=True)
+            actions = out["policy_logits"].argmax(dim=1)
+            if task_type == "classification":
+                correct += (actions == y).sum().item()
+                total += y.numel()
+            else:
+                target_actions = (y.squeeze(-1) > 0).long()
+                correct += (actions == target_actions).sum().item()
+                total += target_actions.numel()
+            value_sum += out["value"].detach().cpu().sum().item()
+
+    accuracy = correct / total if total > 0 else 0.0
+    return {"action_accuracy": accuracy, "avg_value": value_sum / max(1, total)}

--- a/eval/run_evaluation.py
+++ b/eval/run_evaluation.py
@@ -20,10 +20,11 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from config.config import ModelConfig
+from config.config import ModelConfig, PolicyConfig, SignalModelConfig
 from data.prepare_dataset import process_pair
-from eval.agent_eval import evaluate_model
+from eval.agent_eval import evaluate_model, evaluate_policy_agent
 from models.agent_hybrid import build_model
+from models.signal_policy import SignalModel, SignalPolicyAgent
 
 
 def parse_args():
@@ -38,6 +39,9 @@ def parse_args():
     parser.add_argument("--train-ratio", type=float, default=0.7)
     parser.add_argument("--val-ratio", type=float, default=0.15)
     parser.add_argument("--checkpoint-path", default="models/best_model.pt", help="Path to model checkpoint")
+    parser.add_argument("--signal-checkpoint-path", default=None, help="Optional path to signal checkpoint (format string {pair} supported)")
+    parser.add_argument("--policy-checkpoint-path", default=None, help="Optional path to policy checkpoint (format string {pair} supported)")
+    parser.add_argument("--use-policy", action="store_true", help="Load the execution policy head on top of the signal model")
     parser.add_argument("--device", default="cuda")
     return parser.parse_args()
 
@@ -72,6 +76,45 @@ def main():
 
         test_loader = loaders["test"]
         num_features = next(iter(test_loader))[0].shape[-1]
+
+        if args.use_policy:
+            signal_path = (
+                Path(args.signal_checkpoint_path.format(pair=pair))
+                if args.signal_checkpoint_path
+                else Path(f"models/signal_{pair}.pt")
+            )
+            policy_path = (
+                Path(args.policy_checkpoint_path.format(pair=pair))
+                if args.policy_checkpoint_path
+                else Path(f"models/policy_{pair}.pt")
+            )
+            if not signal_path.exists() or not policy_path.exists():
+                print(
+                    f"[error] signal/policy checkpoint missing: {signal_path} or {policy_path}"
+                )
+                continue
+
+            signal_cfg = SignalModelConfig(
+                num_features=num_features,
+                num_classes=3 if args.task_type == "classification" else None,
+                output_dim=1,
+            )
+            signal_dim = SignalModel(signal_cfg).signal_dim
+            policy_cfg = PolicyConfig(
+                input_dim=signal_dim,
+                num_actions=3 if args.task_type == "classification" else 2,
+            )
+            agent = SignalPolicyAgent.load(
+                signal_cfg,
+                policy_cfg,
+                str(signal_path),
+                str(policy_path),
+                device,
+            )
+            metrics = evaluate_policy_agent(agent, test_loader, task_type=args.task_type)
+            results[pair_name] = metrics
+            print(f"[eval-policy] {pair_name}: {metrics}")
+            continue
 
         model_cfg = ModelConfig(
             num_features=num_features,

--- a/export/agent_export.py
+++ b/export/agent_export.py
@@ -2,6 +2,7 @@ import torch
 
 from config.config import ExportConfig
 from models.agent_hybrid import HybridCNNLSTMAttention
+from models.signal_policy import SignalPolicyAgent
 
 
 def export_to_onnx(
@@ -26,3 +27,36 @@ def export_to_onnx(
         dynamic_axes=dynamic_axes,
     )
     print(f"Exported ONNX model to {export_cfg.onnx_path}")
+
+
+def export_signal_policy_to_onnx(
+    agent: SignalPolicyAgent,
+    export_cfg: ExportConfig,
+    example_input: torch.Tensor,
+    task_type: str = "classification",
+):
+    agent.eval()
+    input_names = ["input"]
+    output_names = ["policy_logits", "value"]
+    if task_type == "classification":
+        output_names.append("direction_logits")
+    dynamic_axes = {name: {0: "batch"} for name in input_names + output_names}
+
+    def _forward(x):
+        out = agent(x, detach_signal=True)
+        outputs = [out["policy_logits"], out["value"]]
+        if task_type == "classification" and "direction_logits" in out["signal"]["aux"]:
+            outputs.append(out["signal"]["aux"]["direction_logits"])
+        return tuple(outputs)
+
+    torch.onnx.export(
+        _forward,
+        example_input,
+        export_cfg.onnx_path,
+        export_params=True,
+        opset_version=export_cfg.opset_version,
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_axes=dynamic_axes,
+    )
+    print(f"Exported signal+policy ONNX model to {export_cfg.onnx_path}")

--- a/models/signal_policy.py
+++ b/models/signal_policy.py
@@ -1,0 +1,133 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from config.config import PolicyConfig, SignalModelConfig
+from models.agent_hybrid import TemporalAttention
+
+
+class SignalBackbone(nn.Module):
+    """CNN + LSTM + attention encoder reused by both signal heads and the policy."""
+
+    def __init__(self, cfg: SignalModelConfig):
+        super().__init__()
+        padding = cfg.cnn_kernel_size // 2
+        self.cnn = nn.Conv1d(
+            in_channels=cfg.num_features,
+            out_channels=cfg.cnn_num_filters,
+            kernel_size=cfg.cnn_kernel_size,
+            padding=padding,
+        )
+        self.lstm = nn.LSTM(
+            input_size=cfg.num_features,
+            hidden_size=cfg.hidden_size_lstm,
+            num_layers=cfg.num_layers_lstm,
+            batch_first=True,
+        )
+        attn_input_dim = cfg.hidden_size_lstm + cfg.cnn_num_filters
+        self.attention = TemporalAttention(attn_input_dim, cfg.attention_dim)
+        self.output_dim = attn_input_dim
+
+    def forward(self, x: torch.Tensor):
+        lstm_out, _ = self.lstm(x)  # [B, T, H_lstm]
+        cnn_in = x.permute(0, 2, 1)
+        cnn_features = F.relu(self.cnn(cnn_in)).permute(0, 2, 1)
+        combined = torch.cat([lstm_out, cnn_features], dim=-1)
+        context, attn_weights = self.attention(combined)
+        return context, attn_weights
+
+
+class SignalModel(nn.Module):
+    """Hybrid encoder with optional forecasting and direction heads."""
+
+    def __init__(self, cfg: SignalModelConfig):
+        super().__init__()
+        self.cfg = cfg
+        self.backbone = SignalBackbone(cfg)
+        self.dropout = nn.Dropout(cfg.signal_dropout)
+        self.head_direction = (
+            nn.Linear(self.backbone.output_dim, cfg.num_classes or 3)
+            if cfg.use_direction_head
+            else None
+        )
+        self.head_forecast = (
+            nn.Linear(self.backbone.output_dim, cfg.forecast_output_dim)
+            if cfg.use_forecast_head
+            else None
+        )
+
+    @property
+    def signal_dim(self) -> int:
+        return self.backbone.output_dim
+
+    def forward(self, x: torch.Tensor):
+        embedding, attn_weights = self.backbone(x)
+        embedding = self.dropout(embedding)
+        aux_outputs = {}
+        if self.head_direction is not None:
+            aux_outputs["direction_logits"] = self.head_direction(embedding)
+        if self.head_forecast is not None:
+            aux_outputs["forecast"] = self.head_forecast(embedding)
+        return {"embedding": embedding, "aux": aux_outputs, "attn": attn_weights}
+
+
+class ExecutionPolicy(nn.Module):
+    """PPO/A3C style execution head that consumes signal embeddings."""
+
+    def __init__(self, cfg: PolicyConfig):
+        super().__init__()
+        value_hidden = cfg.value_hidden_dim or cfg.hidden_dim
+        self.policy_net = nn.Sequential(
+            nn.Linear(cfg.input_dim, cfg.hidden_dim),
+            nn.ReLU(),
+            nn.Dropout(cfg.dropout),
+            nn.Linear(cfg.hidden_dim, cfg.num_actions),
+        )
+        self.value_net = nn.Sequential(
+            nn.Linear(cfg.input_dim, value_hidden),
+            nn.ReLU(),
+            nn.Dropout(cfg.dropout),
+            nn.Linear(value_hidden, 1),
+        )
+
+    def forward(self, signal_embedding: torch.Tensor, detach_signal: bool = False):
+        if detach_signal:
+            signal_embedding = signal_embedding.detach()
+        policy_logits = self.policy_net(signal_embedding)
+        value = self.value_net(signal_embedding).squeeze(-1)
+        return policy_logits, value
+
+
+class SignalPolicyAgent(nn.Module):
+    """End-to-end module combining the signal model with the execution policy."""
+
+    def __init__(self, signal_model: SignalModel, policy: ExecutionPolicy):
+        super().__init__()
+        self.signal_model = signal_model
+        self.policy = policy
+
+    def forward(self, x: torch.Tensor, detach_signal: bool = False):
+        signal_out = self.signal_model(x)
+        logits, value = self.policy(signal_out["embedding"], detach_signal=detach_signal)
+        return {
+            "policy_logits": logits,
+            "value": value,
+            "signal": signal_out,
+        }
+
+    @classmethod
+    def load(
+        cls,
+        signal_cfg: SignalModelConfig,
+        policy_cfg: PolicyConfig,
+        signal_path: str,
+        policy_path: str,
+        device: torch.device,
+    ) -> "SignalPolicyAgent":
+        signal_model = SignalModel(signal_cfg).to(device)
+        policy = ExecutionPolicy(policy_cfg).to(device)
+        signal_state = torch.load(signal_path, map_location=device)
+        policy_state = torch.load(policy_path, map_location=device)
+        signal_model.load_state_dict(signal_state)
+        policy.load_state_dict(policy_state)
+        return cls(signal_model, policy)

--- a/train/agent_train.py
+++ b/train/agent_train.py
@@ -3,8 +3,15 @@ from typing import Dict, List, Tuple
 import torch
 from torch.utils.data import DataLoader
 
-from config.config import TrainingConfig
+from typing import Dict, List, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+
+from config.config import PolicyConfig, RLTrainingConfig, TrainingConfig
 from models.agent_hybrid import HybridCNNLSTMAttention
+from models.signal_policy import ExecutionPolicy, SignalModel
 
 
 def _to_device(batch, device):
@@ -128,3 +135,161 @@ def train_model(
         model.load_state_dict(best_state)
 
     return history
+
+
+def _signal_losses(signal_out: Dict, targets: torch.Tensor, task_type: str):
+    losses = []
+    metrics = {}
+    aux = signal_out.get("aux", {})
+    if "direction_logits" in aux and task_type == "classification":
+        cls_loss = torch.nn.functional.cross_entropy(aux["direction_logits"], targets.long())
+        losses.append(cls_loss)
+        metrics["direction_acc"] = _classification_metrics(aux["direction_logits"], targets)
+    if "forecast" in aux:
+        forecast_target = targets.float().unsqueeze(-1) if targets.dim() == 1 else targets.float()
+        reg_loss = torch.nn.functional.mse_loss(aux["forecast"], forecast_target)
+        losses.append(reg_loss)
+        metrics["forecast_rmse"] = _regression_rmse(aux["forecast"], forecast_target)
+    total_loss = sum(losses) if losses else torch.tensor(0.0, device=targets.device)
+    return total_loss, metrics
+
+
+def pretrain_signal_model(
+    signal_model: SignalModel,
+    train_loader: DataLoader,
+    val_loader: DataLoader,
+    cfg: TrainingConfig,
+    task_type: str = "classification",
+) -> Dict[str, List[float]]:
+    device_str = cfg.device
+    if device_str.startswith("cuda") and not torch.cuda.is_available():
+        device_str = "cpu"
+    device = torch.device(device_str)
+    signal_model.to(device)
+
+    optimizer = torch.optim.Adam(
+        signal_model.parameters(), lr=cfg.learning_rate, weight_decay=cfg.weight_decay
+    )
+
+    history = {"train_loss": [], "val_loss": [], "val_metric": []}
+    best_metric = -float("inf")
+    best_state = None
+
+    for epoch in range(1, cfg.epochs + 1):
+        signal_model.train()
+        running_loss = 0.0
+        for step, batch in enumerate(train_loader, start=1):
+            x, y = _to_device(batch, device)
+            signal_out = signal_model(x)
+            loss, _ = _signal_losses(signal_out, y, task_type)
+            loss.backward()
+            if cfg.grad_clip:
+                torch.nn.utils.clip_grad_norm_(signal_model.parameters(), cfg.grad_clip)
+            optimizer.step()
+            optimizer.zero_grad()
+            running_loss += loss.item()
+            if step % cfg.log_every == 0:
+                print(f"[signal] epoch {epoch} step {step} loss {running_loss / step:.4f}")
+
+        val_loss, val_metric = _evaluate_signal(signal_model, val_loader, device, task_type)
+        history["train_loss"].append(running_loss / max(1, len(train_loader)))
+        history["val_loss"].append(val_loss)
+        history["val_metric"].append(val_metric)
+
+        if val_metric > best_metric:
+            best_metric = val_metric
+            best_state = {k: v.cpu() for k, v in signal_model.state_dict().items()}
+            if cfg.checkpoint_path:
+                torch.save(best_state, cfg.checkpoint_path)
+
+        print(
+            f"[signal] epoch {epoch}/{cfg.epochs} train_loss {history['train_loss'][-1]:.4f} "
+            f"val_loss {val_loss:.4f} val_metric {val_metric:.4f}"
+        )
+
+    if best_state is not None:
+        signal_model.load_state_dict(best_state)
+
+    return history
+
+
+def _evaluate_signal(signal_model: SignalModel, loader: DataLoader, device, task_type: str):
+    signal_model.eval()
+    total_loss = 0.0
+    total_metric = 0.0
+    batches = 0
+    with torch.no_grad():
+        for batch in loader:
+            x, y = _to_device(batch, device)
+            signal_out = signal_model(x)
+            loss, metrics = _signal_losses(signal_out, y, task_type)
+            total_loss += loss.item()
+            metric_val = metrics.get("direction_acc", metrics.get("forecast_rmse", 0.0))
+            total_metric += metric_val
+            batches += 1
+    return total_loss / max(1, batches), total_metric / max(1, batches)
+
+
+def _prepare_actions_and_rewards(targets: torch.Tensor, task_type: str):
+    if task_type == "classification":
+        actions = targets.long()
+        reward_lookup = torch.tensor([-1.0, 0.0, 1.0], device=targets.device)
+        rewards = reward_lookup[actions.clamp(max=len(reward_lookup) - 1)]
+    else:
+        rewards = targets.squeeze(-1).float()
+        actions = (rewards > 0).long()
+    return actions, rewards
+
+
+def train_execution_policy(
+    signal_model: SignalModel,
+    policy_head: ExecutionPolicy,
+    train_loader: DataLoader,
+    cfg: RLTrainingConfig,
+    task_type: str = "classification",
+):
+    device = next(signal_model.parameters()).device
+    policy_head.to(device)
+    optimizer = torch.optim.Adam(policy_head.parameters(), lr=cfg.learning_rate)
+
+    for epoch in range(1, cfg.epochs + 1):
+        policy_head.train()
+        running_loss = 0.0
+        for step, batch in enumerate(train_loader, start=1):
+            x, y = _to_device(batch, device)
+            with torch.no_grad():
+                signal_out = signal_model(x)
+                signal_embedding = signal_out["embedding"].detach() if cfg.detach_signal else signal_out["embedding"]
+
+            logits, value = policy_head(signal_embedding, detach_signal=False)
+            actions, rewards = _prepare_actions_and_rewards(y, task_type)
+
+            log_probs = F.log_softmax(logits, dim=-1)
+            probs = log_probs.exp()
+            action_log_probs = log_probs.gather(1, actions.unsqueeze(-1)).squeeze(-1)
+            advantage = rewards - value.detach()
+
+            policy_loss = -(advantage * action_log_probs).mean()
+            value_loss = advantage.pow(2).mean()
+            entropy = -(probs * log_probs).sum(dim=1).mean()
+
+            loss = policy_loss + cfg.value_coef * value_loss - cfg.entropy_coef * entropy
+            loss.backward()
+            if cfg.grad_clip:
+                torch.nn.utils.clip_grad_norm_(policy_head.parameters(), cfg.grad_clip)
+            optimizer.step()
+            optimizer.zero_grad()
+
+            running_loss += loss.item()
+            if step % 50 == 0:
+                print(
+                    f"[policy] epoch {epoch} step {step} loss {running_loss / step:.4f} "
+                    f"policy_loss {policy_loss.item():.4f} value_loss {value_loss.item():.4f}"
+                )
+
+        print(f"[policy] epoch {epoch}/{cfg.epochs} loss {running_loss / max(1, len(train_loader)):.4f}")
+
+    if cfg.checkpoint_path:
+        torch.save({k: v.cpu() for k, v in policy_head.state_dict().items()}, cfg.checkpoint_path)
+
+    return policy_head

--- a/train/run_training.py
+++ b/train/run_training.py
@@ -20,10 +20,18 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from config.config import ModelConfig, TrainingConfig
-from data.prepare_dataset import process_pair
-from models.agent_hybrid import build_model
-from train.agent_train import train_model
+from config.config import (  # noqa: E402
+    PolicyConfig,
+    RLTrainingConfig,
+    SignalModelConfig,
+    TrainingConfig,
+)
+from data.prepare_dataset import process_pair  # noqa: E402
+from models.signal_policy import ExecutionPolicy, SignalModel  # noqa: E402
+from train.agent_train import (  # noqa: E402
+    pretrain_signal_model,
+    train_execution_policy,
+)
 
 
 def parse_args():
@@ -43,6 +51,13 @@ def parse_args():
     parser.add_argument("--weight-decay", type=float, default=0.0)
     parser.add_argument("--device", default="cuda")
     parser.add_argument("--checkpoint-path", default="models/best_model.pt")
+    parser.add_argument("--signal-checkpoint-path", default="models/signal_{pair}.pt")
+    parser.add_argument("--policy-checkpoint-path", default="models/policy_{pair}.pt")
+    parser.add_argument("--pretrain-epochs", type=int, default=5, help="epochs for signal pretraining")
+    parser.add_argument("--policy-epochs", type=int, default=5, help="epochs for execution policy training")
+    parser.add_argument("--entropy-coef", type=float, default=0.01)
+    parser.add_argument("--value-coef", type=float, default=0.5)
+    parser.add_argument("--detach-signal", action="store_true", help="freeze signal encoder during policy training")
     return parser.parse_args()
 
 
@@ -79,36 +94,57 @@ def main():
         val_loader = loaders["val"]
         num_features = next(iter(train_loader))[0].shape[-1]
 
-        # Derive checkpoint path per pair unless user overrides.
-        if args.checkpoint_path == "models/best_model.pt":
-            ckpt_path = Path("models") / f"{pair}_best_model.pt"
-        else:
-            ckpt_path = Path(args.checkpoint_path)
-        ckpt_path.parent.mkdir(parents=True, exist_ok=True)
+        signal_ckpt = Path(args.signal_checkpoint_path.format(pair=pair))
+        policy_ckpt = Path(args.policy_checkpoint_path.format(pair=pair))
+        signal_ckpt.parent.mkdir(parents=True, exist_ok=True)
+        policy_ckpt.parent.mkdir(parents=True, exist_ok=True)
 
-        model_cfg = ModelConfig(
+        signal_cfg = SignalModelConfig(
             num_features=num_features,
             num_classes=3 if args.task_type == "classification" else None,
+            output_dim=1,
         )
-        train_cfg = TrainingConfig(
+        pretrain_cfg = TrainingConfig(
             batch_size=args.batch_size,
-            epochs=args.epochs,
+            epochs=args.pretrain_epochs,
             learning_rate=args.learning_rate,
             weight_decay=args.weight_decay,
             device=device,
-            checkpoint_path=str(ckpt_path),
+            checkpoint_path=str(signal_ckpt),
         )
 
-        model = build_model(model_cfg, task_type=args.task_type)
-        history = train_model(
-            model,
+        signal_model = SignalModel(signal_cfg)
+        signal_history = pretrain_signal_model(
+            signal_model,
             train_loader,
             val_loader,
-            train_cfg,
+            pretrain_cfg,
             task_type=args.task_type,
         )
-        results[pair_name] = history
-        print(f"[done] {pair_name} training complete.")
+
+        policy_cfg = PolicyConfig(
+            input_dim=signal_model.signal_dim,
+            num_actions=3 if args.task_type == "classification" else 2,
+        )
+        rl_cfg = RLTrainingConfig(
+            epochs=args.policy_epochs,
+            learning_rate=args.learning_rate,
+            entropy_coef=args.entropy_coef,
+            value_coef=args.value_coef,
+            detach_signal=args.detach_signal,
+            checkpoint_path=str(policy_ckpt),
+        )
+        policy_head = ExecutionPolicy(policy_cfg)
+        train_execution_policy(
+            signal_model,
+            policy_head,
+            train_loader,
+            rl_cfg,
+            task_type=args.task_type,
+        )
+
+        results[pair_name] = {"signal_history": signal_history}
+        print(f"[done] {pair_name} signal+policy training complete.")
 
     return results
 


### PR DESCRIPTION
## Summary
- add dedicated signal model configs plus hybrid encoder/policy modules with load helpers for deployment
- update training flow to pretrain the signal model before optimizing an execution policy head with RL-style objectives and new CLI options
- extend evaluation and export utilities to compose signal and policy components, including ONNX export support

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929b613d348832eb84d469d023fda7b)