### PR TITLE
Add intrinsic-time bar options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This repository trains and evaluates a foreign-exchange forecasting model on min
 4) Optional sentiment: add `--run-gdelt-download` to pull GDELT GKG files before training. [Leetaru & Schrodt 2013]
 5) Optional mini-game: when prompted during training, press `y` to launch; quit with `Q` (may slow training).
 
+### Intrinsic-time bars (directional-change)
+- Swap minute bars for intrinsic-time bars based on directional-change thresholds using `--intrinsic-time` and configure the move sizes with `--dc-threshold-up` / `--dc-threshold-down`.
+- Example: `python data/prepare_dataset.py --pairs gbpusd --intrinsic-time --dc-threshold-up 0.0005`
+- The same flags are available in `utils/run_training_pipeline.py` to keep training/eval consistent.
+
 ## Finetuning NovaSky models (LLMs)
 - Resource-friendly (recommended on limited VRAM): `python train/run_finetune_novasky_lora.py --model-name-or-path /path/to/NovaSky-AI/Sky-T1-32B-Flash --output-dir models/novasky-lora --use-4bit --bf16 --per-device-train-batch-size 1 --gradient-accumulation-steps 32 --max-length 1024`
 - Full finetune (heavier): `python train/run_finetune_novasky.py --model-name-or-path /path/to/NovaSky-AI/Sky-T1-32B-Flash --output-dir models/novasky-full --per-device-train-batch-size 1 --gradient-accumulation-steps 32 --max-length 1024`

--- a/data/prepare_dataset.py
+++ b/data/prepare_dataset.py
@@ -20,6 +20,7 @@ if str(ROOT) not in sys.path:
 from config.config import DataConfig
 from data.agent_data import DataAgent
 from features.agent_features import build_feature_frame
+from features.intrinsic_time import build_intrinsic_time_bars
 
 
 def parse_args():
@@ -33,6 +34,23 @@ def parse_args():
     parser.add_argument("--flat-threshold", type=float, default=0.0001, help="Flat class threshold for log returns")
     parser.add_argument("--train-ratio", type=float, default=0.7, help="Train fraction (time-ordered)")
     parser.add_argument("--val-ratio", type=float, default=0.15, help="Validation fraction (time-ordered)")
+    parser.add_argument(
+        "--intrinsic-time",
+        action="store_true",
+        help="Convert minute bars to intrinsic-time bars via directional-change events.",
+    )
+    parser.add_argument(
+        "--dc-threshold-up",
+        type=float,
+        default=0.001,
+        help="Fractional increase needed to flag an upward directional change (e.g., 0.001=0.1%).",
+    )
+    parser.add_argument(
+        "--dc-threshold-down",
+        type=float,
+        default=None,
+        help="Fractional decrease needed to flag a downward directional change. Defaults to dc-threshold-up.",
+    )
     return parser.parse_args()
 
 
@@ -111,7 +129,19 @@ def process_pair(pair: str, args):
         input_root = (ROOT / input_root).resolve()
 
     raw_df = _load_pair_data(pair, input_root, years)
-    feature_df = build_feature_frame(raw_df)
+    df_for_features = raw_df
+    if args.intrinsic_time:
+        df_for_features = build_intrinsic_time_bars(
+            raw_df,
+            up_threshold=args.dc_threshold_up,
+            down_threshold=args.dc_threshold_down,
+        )
+        print(
+            f"[intrinsic] reduced {len(raw_df):,} -> {len(df_for_features):,} bars using "
+            f"DC thresholds up={args.dc_threshold_up}, down={args.dc_threshold_down or args.dc_threshold_up}"
+        )
+
+    feature_df = build_feature_frame(df_for_features)
     feature_df["datetime"] = pd.to_datetime(feature_df["datetime"])
 
     train_range, val_range, test_range = _compute_time_ranges(

--- a/features/intrinsic_time.py
+++ b/features/intrinsic_time.py
@@ -1,0 +1,149 @@
+"""Directional-change and intrinsic-time bar utilities.
+
+The functions here are pure, stateless helpers to compute directional-change
+(DC) events and overshoots from a price series, then convert those events into
+intrinsic-time bars that can replace fixed clock-time bars during dataset
+preparation.
+"""
+
+from typing import Optional, Sequence
+
+import pandas as pd
+
+
+def _validate_thresholds(up_threshold: float, down_threshold: float) -> None:
+    if up_threshold <= 0 or down_threshold <= 0:
+        raise ValueError("Directional-change thresholds must be positive.")
+
+
+def detect_directional_changes(
+    prices: pd.Series,
+    up_threshold: float,
+    down_threshold: Optional[float] = None,
+    timestamps: Optional[Sequence] = None,
+) -> pd.DataFrame:
+    """
+    Detect directional-change events and overshoots using relative price moves.
+
+    Args:
+        prices: Series of prices ordered in time.
+        up_threshold: Fractional increase required to flag an upward directional
+            change (e.g., 0.001 == 0.1%).
+        down_threshold: Fractional decrease required to flag a downward
+            directional change. Defaults to ``up_threshold`` if omitted.
+        timestamps: Optional timestamps aligned with ``prices``. If omitted, the
+            price index is used.
+
+    Returns:
+        DataFrame with columns ``["idx", "timestamp", "price", "direction",
+        "overshoot"]``. The first DC starts when either threshold is breached;
+        overshoot tracks any additional favorable move until the next reversal
+        triggers.
+    """
+
+    if prices.empty:
+        raise ValueError("Price series must contain at least one observation.")
+    if down_threshold is None:
+        down_threshold = up_threshold
+    _validate_thresholds(up_threshold, down_threshold)
+
+    ts = pd.Series(timestamps) if timestamps is not None else prices.index
+
+    extreme_price = float(prices.iloc[0])
+    current_direction: Optional[str] = None
+    event_price = extreme_price
+
+    events = []
+
+    def append_event(idx: int, price: float, direction: str, overshoot: float = 0.0) -> None:
+        events.append(
+            {
+                "idx": idx,
+                "timestamp": ts.iloc[idx] if hasattr(ts, "iloc") else ts[idx],
+                "price": price,
+                "direction": direction,
+                "overshoot": overshoot,
+            }
+        )
+
+    for i in range(1, len(prices)):
+        price = float(prices.iloc[i])
+
+        if current_direction is None:
+            change = (price - extreme_price) / extreme_price
+            if change >= up_threshold:
+                current_direction = "up"
+                event_price = price
+                extreme_price = price
+                append_event(i, price, current_direction)
+            elif change <= -down_threshold:
+                current_direction = "down"
+                event_price = price
+                extreme_price = price
+                append_event(i, price, current_direction)
+            continue
+
+        if current_direction == "up":
+            if price > extreme_price:
+                extreme_price = price
+                overshoot = (extreme_price - event_price) / event_price
+                events[-1]["overshoot"] = overshoot
+            drawdown = (price - extreme_price) / extreme_price
+            if drawdown <= -down_threshold:
+                current_direction = "down"
+                event_price = price
+                extreme_price = price
+                append_event(i, price, current_direction)
+        else:
+            if price < extreme_price:
+                extreme_price = price
+                overshoot = (event_price - extreme_price) / event_price
+                events[-1]["overshoot"] = overshoot
+            rebound = (price - extreme_price) / extreme_price
+            if rebound >= up_threshold:
+                current_direction = "up"
+                event_price = price
+                extreme_price = price
+                append_event(i, price, current_direction)
+
+    return pd.DataFrame(events)
+
+
+def build_intrinsic_time_bars(
+    df: pd.DataFrame,
+    price_col: str = "close",
+    datetime_col: str = "datetime",
+    up_threshold: float = 0.001,
+    down_threshold: Optional[float] = None,
+) -> pd.DataFrame:
+    """
+    Convert a clock-time price frame into intrinsic-time bars using DC events.
+
+    Args:
+        df: DataFrame with at least ``price_col`` and ``datetime_col`` columns,
+            ordered by time.
+        price_col: Column containing prices.
+        datetime_col: Timestamp column aligned to prices.
+        up_threshold: Fractional increase needed for an upward DC.
+        down_threshold: Fractional decrease needed for a downward DC. Defaults to
+            ``up_threshold`` if omitted.
+
+    Returns:
+        A copy of ``df`` filtered to directional-change event rows. Extra columns
+        ``direction`` and ``overshoot`` annotate the DC direction and overshoot
+        magnitude observed before reversal.
+    """
+
+    events = detect_directional_changes(
+        df[price_col].reset_index(drop=True),
+        up_threshold=up_threshold,
+        down_threshold=down_threshold,
+        timestamps=df[datetime_col].reset_index(drop=True),
+    )
+    if events.empty:
+        raise ValueError("No directional-change events detected; consider lowering thresholds.")
+
+    bars = df.reset_index(drop=True).iloc[events["idx"].to_list()].copy()
+    bars["direction"] = events["direction"].to_list()
+    bars["overshoot"] = events["overshoot"].to_list()
+    return bars.reset_index(drop=True)

--- a/utils/run_training_pipeline.py
+++ b/utils/run_training_pipeline.py
@@ -63,6 +63,23 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--flat-threshold", type=float, default=0.0001)
     parser.add_argument("--train-ratio", type=float, default=0.7)
     parser.add_argument("--val-ratio", type=float, default=0.15)
+    parser.add_argument(
+        "--intrinsic-time",
+        action="store_true",
+        help="Convert minute bars to intrinsic-time bars via directional-change events before feature building.",
+    )
+    parser.add_argument(
+        "--dc-threshold-up",
+        type=float,
+        default=0.001,
+        help="Fractional increase needed to flag an upward directional change (e.g., 0.001=0.1%).",
+    )
+    parser.add_argument(
+        "--dc-threshold-down",
+        type=float,
+        default=None,
+        help="Fractional decrease needed to flag a downward directional change. Defaults to dc-threshold-up.",
+    )
     parser.add_argument("--batch-size", type=int, default=64)
     parser.add_argument("--epochs", type=int, default=10)
     parser.add_argument("--learning-rate", type=float, default=1e-3)


### PR DESCRIPTION
## Summary
- add directional-change detection utilities for intrinsic-time bar construction
- allow dataset prep and training pipeline to switch from minute bars to intrinsic-time bars via new CLI flags
- document intrinsic-time usage and thresholds in the README

## Testing
- python -m compileall features/intrinsic_time.py data/prepare_dataset.py utils/run_training_pipeline.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929b3d878c8832eb8935f0c9b3a9c9d)