### PR TITLE
Refactor hybrid agent heads

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -27,6 +27,18 @@ class ModelConfig:
     dropout: float = 0.1
     num_classes: Optional[int] = 3  # set to None for regression
     output_dim: int = 1  # used for regression
+    bidirectional: bool = True
+    num_dir_classes: Optional[int] = None
+    return_dim: Optional[int] = None
+    num_volatility_classes: int = 2
+
+    def __post_init__(self) -> None:
+        # Preserve backward compatibility with older configs that only specify
+        # num_classes/output_dim while allowing explicit head dimensions.
+        if self.num_dir_classes is None:
+            self.num_dir_classes = self.num_classes or 3
+        if self.return_dim is None:
+            self.return_dim = self.output_dim
 
 
 @dataclass

--- a/eval/ensemble_timesfm.py
+++ b/eval/ensemble_timesfm.py
@@ -164,8 +164,8 @@ def main():
             for seq, close_seq in zip(sequences, close_windows):
                 x = torch.tensor(seq, dtype=torch.float32, device=device).unsqueeze(0)
                 with torch.no_grad():
-                    out, _ = hybrid(x)
-                hybrid_ret = out.squeeze().item()
+                    outputs, _ = hybrid(x)
+                hybrid_ret = outputs["return"].squeeze().item()
 
                 tfm_forecast = tfm_model.forecast_naive(horizon=args.t_out, inputs=[close_seq])[0]
                 if tfm_forecast is None or len(tfm_forecast) == 0:

--- a/models/agent_hybrid.py
+++ b/models/agent_hybrid.py
@@ -22,7 +22,7 @@ class TemporalAttention(nn.Module):
 
 class HybridCNNLSTMAttention(nn.Module):
     """
-    CNN + LSTM + temporal attention hybrid model.
+    CNN + BiLSTM + temporal attention hybrid model with multi-head outputs.
     """
 
     def __init__(self, cfg: ModelConfig, task_type: str = "classification"):
@@ -43,22 +43,21 @@ class HybridCNNLSTMAttention(nn.Module):
             hidden_size=cfg.hidden_size_lstm,
             num_layers=cfg.num_layers_lstm,
             batch_first=True,
+            bidirectional=cfg.bidirectional,
         )
 
-        attn_input_dim = cfg.hidden_size_lstm + cfg.cnn_num_filters
+        lstm_factor = 2 if cfg.bidirectional else 1
+        attn_input_dim = lstm_factor * cfg.hidden_size_lstm + cfg.cnn_num_filters
         self.attention = TemporalAttention(attn_input_dim, cfg.attention_dim)
 
-        head_input = attn_input_dim
-        if task_type == "classification":
-            output_dim = cfg.num_classes or 3
-        else:
-            output_dim = cfg.output_dim
         self.dropout = nn.Dropout(cfg.dropout)
-        self.fc = nn.Linear(head_input, output_dim)
+        self.head_direction = nn.Linear(attn_input_dim, cfg.num_dir_classes)
+        self.head_return = nn.Linear(attn_input_dim, cfg.return_dim)
+        self.head_volatility = nn.Linear(attn_input_dim, cfg.num_volatility_classes)
 
     def forward(self, x: torch.Tensor):
         # x: [B, T, F]
-        lstm_out, _ = self.lstm(x)  # [B, T, H_lstm]
+        lstm_out, _ = self.lstm(x)  # [B, T, H_lstm * (1 or 2)]
 
         cnn_in = x.permute(0, 2, 1)  # [B, F, T]
         cnn_features = F.relu(self.cnn(cnn_in)).permute(0, 2, 1)  # [B, T, H_cnn]
@@ -67,9 +66,25 @@ class HybridCNNLSTMAttention(nn.Module):
 
         context, attn_weights = self.attention(combined)
         context = self.dropout(context)
-        output = self.fc(context)
-        return output, attn_weights
+        outputs = {
+            "direction_logits": self.head_direction(context),
+            "return": self.head_return(context),
+            "volatility_logits": self.head_volatility(context),
+        }
+        return outputs, attn_weights
 
 
-def build_model(cfg: ModelConfig, task_type: str = "classification") -> HybridCNNLSTMAttention:
+def build_model(
+    cfg: ModelConfig,
+    task_type: str = "classification",
+    num_dir_classes: int | None = None,
+    num_volatility_classes: int | None = None,
+    return_dim: int | None = None,
+) -> HybridCNNLSTMAttention:
+    if num_dir_classes is not None:
+        cfg.num_dir_classes = num_dir_classes
+    if num_volatility_classes is not None:
+        cfg.num_volatility_classes = num_volatility_classes
+    if return_dim is not None:
+        cfg.return_dim = return_dim
     return HybridCNNLSTMAttention(cfg, task_type=task_type)

--- a/train/agent_train.py
+++ b/train/agent_train.py
@@ -24,6 +24,12 @@ def _regression_rmse(preds: torch.Tensor, targets: torch.Tensor) -> float:
     return torch.sqrt(mse).item()
 
 
+def _select_outputs(outputs: Dict[str, torch.Tensor], task_type: str) -> torch.Tensor:
+    if task_type == "classification":
+        return outputs["direction_logits"]
+    return outputs["return"]
+
+
 def _align_regression(preds: torch.Tensor, targets: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     preds = preds.squeeze(-1)
     targets = targets.squeeze(-1)
@@ -44,7 +50,8 @@ def _evaluate(
     with torch.no_grad():
         for batch in loader:
             x, y = _to_device(batch, device)
-            logits, _ = model(x)
+            outputs, _ = model(x)
+            logits = _select_outputs(outputs, task_type)
             if task_type == "regression":
                 logits, y = _align_regression(logits, y)
             loss = loss_fn(logits, y)
@@ -88,7 +95,8 @@ def train_model(
         running_loss = 0.0
         for step, batch in enumerate(train_loader, start=1):
             x, y = _to_device(batch, device)
-            logits, _ = model(x)
+            outputs, _ = model(x)
+            logits = _select_outputs(outputs, task_type)
             if task_type == "regression":
                 logits, y = _align_regression(logits, y)
             loss = loss_fn(logits, y)


### PR DESCRIPTION
## Summary
- refactor the hybrid encoder to combine distinct CNN and bidirectional LSTM branches under temporal attention and expose multi-head outputs
- allow ModelConfig/build_model to configure head dimensions and add volatility/regression heads with shared dropout
- update training and evaluation utilities to read the new output dictionary and keep regression ensemble evaluation compatible

## Testing
- python -m compileall config/config.py models/agent_hybrid.py train/agent_train.py eval/agent_eval.py eval/ensemble_timesfm.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692960fd1c5c832ea31b13938f34990d)