### PR TITLE
Add simulated retail execution environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ peft>=0.13.2
 bitsandbytes>=0.43.3
 pytest>=7.4.0
 testcontainers>=4.6.0
+backtesting>=0.3.2


### PR DESCRIPTION
## Summary
- add a configurable simulated retail execution environment with slippage, spread, delay, and limit-fill modeling
- expose a lightweight gym-like API plus action/observation helpers for RL agents
- log execution metrics and enforce FIFO position accounting with retail-calibrated defaults

## Testing
- python -m compileall execution/simulated_retail_env.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929b4cec8cc832e8b9de5da1718a08c)