### PR TITLE
Add trend, volatility regime, and candle heads to multitask model

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -55,6 +55,9 @@ class MultiTaskModelConfig:
     dropout: float = 0.1
     num_dir_classes: int = 3
     num_vol_classes: int = 2
+    num_trend_classes: int = 3
+    num_vol_regime_classes: int = 3
+    num_candle_classes: int = 4
 
 
 @dataclass
@@ -83,6 +86,9 @@ class MultiTaskLossWeights:
     return_reg: float = 1.0
     next_close_reg: float = 1.0
     vol_cls: float = 1.0
+    trend_cls: float = 1.0
+    vol_regime_cls: float = 1.0
+    candle_pattern_cls: float = 1.0
 
 
 @dataclass

--- a/data/agent_multitask_data.py
+++ b/data/agent_multitask_data.py
@@ -73,6 +73,9 @@ class MultiTaskDataAgent:
         targets_ret_reg: List[float] = []
         targets_next_close: List[float] = []
         targets_vol_cls: List[int] = []
+        targets_trend_cls: List[int] = []
+        targets_vol_regime_cls: List[int] = []
+        targets_candle_cls: List[int] = []
 
         last_idx = len(df) - t_out
         for idx in range(t_in - 1, last_idx):
@@ -99,11 +102,47 @@ class MultiTaskDataAgent:
             future_vol = float(np.std(future_ret_window))
             vol_label = 1 if (future_vol - past_vol) > self.cfg.vol_min_change else 0
 
+            trend_avg_return = float(np.mean(future_ret_window))
+            trend_label = int(_label_from_return(trend_avg_return, self.cfg.flat_threshold))
+
+            vol_delta = future_vol - past_vol
+            if vol_delta > self.cfg.vol_min_change:
+                vol_regime_label = 2
+            elif vol_delta < -self.cfg.vol_min_change:
+                vol_regime_label = 0
+            else:
+                vol_regime_label = 1
+
+            candle_row = df.iloc[idx]
+            open_price = float(candle_row["open"])
+            high_price = float(candle_row["high"])
+            low_price = float(candle_row["low"])
+            close_price = float(candle_row["close"])
+            range_size = max(high_price - low_price, 1e-8)
+            body = close_price - open_price
+            body_ratio = abs(body) / range_size
+            upper_wick = high_price - max(open_price, close_price)
+            lower_wick = min(open_price, close_price) - low_price
+
+            if body_ratio < 0.1:
+                candle_label = 0  # doji/indecision
+            elif body > 0 and body_ratio > 0.55:
+                candle_label = 1  # strong bullish body
+            elif body < 0 and body_ratio > 0.55:
+                candle_label = 2  # strong bearish body
+            elif lower_wick / range_size > 0.35:
+                candle_label = 3  # hammer/long lower wick
+            else:
+                candle_label = 3
+
             sequences.append(seq)
             targets_dir_cls.append(direction_label)
             targets_ret_reg.append(return_target)
             targets_next_close.append(next_close_target)
             targets_vol_cls.append(vol_label)
+            targets_trend_cls.append(trend_label)
+            targets_vol_regime_cls.append(vol_regime_label)
+            targets_candle_cls.append(candle_label)
 
         if not sequences:
             raise ValueError("No sequences created; check t_in/t_out and data length.")
@@ -113,6 +152,9 @@ class MultiTaskDataAgent:
             "return_reg": np.array(targets_ret_reg),
             "next_close_reg": np.array(targets_next_close),
             "vol_class": np.array(targets_vol_cls),
+            "trend_class": np.array(targets_trend_cls),
+            "vol_regime_class": np.array(targets_vol_regime_cls),
+            "candle_class": np.array(targets_candle_cls),
         }
         return np.stack(sequences), targets
 

--- a/models/agent_multitask.py
+++ b/models/agent_multitask.py
@@ -8,11 +8,14 @@ from models.agent_hybrid import TemporalAttention
 
 class MultiHeadHybrid(nn.Module):
     """
-    Shared CNN + LSTM + temporal attention encoder with four heads:
+    Shared CNN + LSTM + temporal attention encoder with seven heads:
     1) direction classification
     2) return regression
     3) next close regression
     4) volatility direction classification
+    5) trend classification
+    6) volatility regime classification
+    7) candle-pattern classification
     """
 
     def __init__(self, cfg: MultiTaskModelConfig):
@@ -42,6 +45,9 @@ class MultiHeadHybrid(nn.Module):
         self.head_return = nn.Linear(attn_input_dim, 1)
         self.head_next_close = nn.Linear(attn_input_dim, 1)
         self.head_volatility = nn.Linear(attn_input_dim, cfg.num_vol_classes)
+        self.head_trend = nn.Linear(attn_input_dim, cfg.num_trend_classes)
+        self.head_vol_regime = nn.Linear(attn_input_dim, cfg.num_vol_regime_classes)
+        self.head_candle = nn.Linear(attn_input_dim, cfg.num_candle_classes)
 
     def forward(self, x: torch.Tensor):
         # x: [B, T, F]
@@ -59,6 +65,9 @@ class MultiHeadHybrid(nn.Module):
             "return": self.head_return(context),
             "next_close": self.head_next_close(context),
             "volatility_logits": self.head_volatility(context),
+            "trend_logits": self.head_trend(context),
+            "vol_regime_logits": self.head_vol_regime(context),
+            "candle_pattern_logits": self.head_candle(context),
         }
         return outputs, attn_weights
 

--- a/train/agent_train_multitask.py
+++ b/train/agent_train_multitask.py
@@ -25,12 +25,18 @@ def _compute_losses(
 
     losses["direction"] = ce(outputs["direction_logits"], targets["direction_class"])
     losses["volatility"] = ce(outputs["volatility_logits"], targets["vol_class"])
+    losses["trend"] = ce(outputs["trend_logits"], targets["trend_class"])
+    losses["vol_regime"] = ce(outputs["vol_regime_logits"], targets["vol_regime_class"])
+    losses["candle_pattern"] = ce(outputs["candle_pattern_logits"], targets["candle_class"])
     losses["return"] = mse(outputs["return"].squeeze(-1), targets["return_reg"])
     losses["next_close"] = mse(outputs["next_close"].squeeze(-1), targets["next_close_reg"])
 
     total = (
         loss_weights.direction_cls * losses["direction"]
         + loss_weights.vol_cls * losses["volatility"]
+        + loss_weights.trend_cls * losses["trend"]
+        + loss_weights.vol_regime_cls * losses["vol_regime"]
+        + loss_weights.candle_pattern_cls * losses["candle_pattern"]
         + loss_weights.return_reg * losses["return"]
         + loss_weights.next_close_reg * losses["next_close"]
     )
@@ -55,7 +61,16 @@ def _evaluate(
     device,
 ) -> Dict[str, float]:
     model.eval()
-    totals = {"loss": 0.0, "dir_acc": 0.0, "vol_acc": 0.0, "ret_rmse": 0.0, "close_rmse": 0.0}
+    totals = {
+        "loss": 0.0,
+        "dir_acc": 0.0,
+        "vol_acc": 0.0,
+        "trend_acc": 0.0,
+        "vol_regime_acc": 0.0,
+        "candle_acc": 0.0,
+        "ret_rmse": 0.0,
+        "close_rmse": 0.0,
+    }
     batches = 0
     with torch.no_grad():
         for batch in loader:
@@ -65,6 +80,11 @@ def _evaluate(
             totals["loss"] += loss.item()
             totals["dir_acc"] += _classification_accuracy(outputs["direction_logits"], targets["direction_class"])
             totals["vol_acc"] += _classification_accuracy(outputs["volatility_logits"], targets["vol_class"])
+            totals["trend_acc"] += _classification_accuracy(outputs["trend_logits"], targets["trend_class"])
+            totals["vol_regime_acc"] += _classification_accuracy(
+                outputs["vol_regime_logits"], targets["vol_regime_class"]
+            )
+            totals["candle_acc"] += _classification_accuracy(outputs["candle_pattern_logits"], targets["candle_class"])
             totals["ret_rmse"] += _rmse(outputs["return"], targets["return_reg"])
             totals["close_rmse"] += _rmse(outputs["next_close"], targets["next_close_reg"])
             batches += 1
@@ -88,7 +108,15 @@ def train_multitask(
 
     optimizer = torch.optim.Adam(model.parameters(), lr=cfg.learning_rate, weight_decay=cfg.weight_decay)
 
-    history = {"train_loss": [], "val_loss": [], "val_dir_acc": [], "val_vol_acc": []}
+    history = {
+        "train_loss": [],
+        "val_loss": [],
+        "val_dir_acc": [],
+        "val_vol_acc": [],
+        "val_trend_acc": [],
+        "val_vol_regime_acc": [],
+        "val_candle_acc": [],
+    }
     best_loss = float("inf")
     best_state = None
 
@@ -114,6 +142,9 @@ def train_multitask(
         history["val_loss"].append(val_metrics["loss"])
         history["val_dir_acc"].append(val_metrics["dir_acc"])
         history["val_vol_acc"].append(val_metrics["vol_acc"])
+        history["val_trend_acc"].append(val_metrics["trend_acc"])
+        history["val_vol_regime_acc"].append(val_metrics["vol_regime_acc"])
+        history["val_candle_acc"].append(val_metrics["candle_acc"])
 
         is_better = val_metrics["loss"] < best_loss
         if is_better:
@@ -126,6 +157,8 @@ def train_multitask(
             f"epoch {epoch}/{cfg.epochs} train_loss {train_epoch_loss:.4f} "
             f"val_loss {val_metrics['loss']:.4f} "
             f"val_dir_acc {val_metrics['dir_acc']:.4f} val_vol_acc {val_metrics['vol_acc']:.4f} "
+            f"val_trend_acc {val_metrics['trend_acc']:.4f} val_vol_regime_acc {val_metrics['vol_regime_acc']:.4f} "
+            f"val_candle_acc {val_metrics['candle_acc']:.4f} "
             f"val_ret_rmse {val_metrics['ret_rmse']:.6f} val_close_rmse {val_metrics['close_rmse']:.6f}"
         )
 

--- a/train/run_training_multitask.py
+++ b/train/run_training_multitask.py
@@ -1,5 +1,6 @@
 """
-End-to-end training entrypoint for the multi-head model (direction cls, return reg, next-close reg, vol cls).
+End-to-end training entrypoint for the multi-head model (direction cls, trend cls,
+return reg, next-close reg, vol cls, vol regime cls, candle-pattern cls).
 
   python train/run_training_multitask.py \\
     --pairs eurusd,eurgbp,eurjpy,eurchf,euraud,eurcad,eurnzd,gbpusd,gbpjpy,gbpchf,gbpcad,gbpaud,gbpnzd,usdjpy,usdchf,usdcad,audusd,audjpy,audcad,audchf,audnzd,nzdusd,nzdjpy,nzdcad,nzdchf,cadchf,cadjpy,chfjpy,usdbrl,usdrub,usdinr,usdcny,usdzar,usdtry,xauusd \\
@@ -50,6 +51,9 @@ def parse_args():
     parser.add_argument("--loss-w-return", type=float, default=1.0)
     parser.add_argument("--loss-w-next-close", type=float, default=1.0)
     parser.add_argument("--loss-w-vol", type=float, default=1.0)
+    parser.add_argument("--loss-w-trend", type=float, default=1.0)
+    parser.add_argument("--loss-w-vol-regime", type=float, default=1.0)
+    parser.add_argument("--loss-w-candle", type=float, default=1.0)
     return parser.parse_args()
 
 
@@ -107,6 +111,9 @@ def main():
             return_reg=args.loss_w_return,
             next_close_reg=args.loss_w_next_close,
             vol_cls=args.loss_w_vol,
+            trend_cls=args.loss_w_trend,
+            vol_regime_cls=args.loss_w_vol_regime,
+            candle_pattern_cls=args.loss_w_candle,
         )
 
         model = build_multitask_model(model_cfg)


### PR DESCRIPTION
## Summary
- add trend, volatility regime, and candle-pattern heads that share the multitask attention context
- extend configs and multitask data labeling to provide class counts, loss weights, and targets for the new heads
- update training and CLI loops to optimize and log metrics for the added tasks

## Testing
- python -m compileall config models data train *(fails in vendored git-lfs placeholders under models/timesFM)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929623dd578832ea7d6bb6592c44175)