### PR TITLE
Seed retail simulator with default cash

### DIFF
--- a/docs/backtesting_rl_analysis.md
+++ b/docs/backtesting_rl_analysis.md
@@ -1,0 +1,27 @@
+# Backtesting.py fit vs existing RL and execution stack
+
+## Current RL and execution capabilities
+- **A3C harness:** Multi-worker actor-critic training already wraps the hybrid CNN–LSTM–attention encoder. It handles asynchronous rollouts, shared Adam optimizer state, and gradient synchronization with value/policy losses plus entropy regularization. The harness expects a gym-like environment factory, so any backtesting-driven env would plug in via the existing factory hook.
+- **Hybrid feature encoder inside RL:** The RL stack reuses the ModelConfig-driven hybrid encoder (LSTM + Conv1d + attention) as a shared feature extractor before policy/value heads. This keeps RL aligned with the forecasting backbone but currently assumes fixed feature counts and time-major tensors from the data agent.
+- **Retail execution simulator:** A gym-like execution environment exists with spread, slippage, limit-fill probability, decision lag, FIFO PnL, and logging. Rewards are portfolio value deltas, making it suitable for policy evaluation without exchange dependencies.
+- **Risk gating:** A risk manager throttles logits or regression outputs when drawdown, volatility, spread, or no-trade windows are hit. This can be used during backtests to mimic live guardrails by clamping actions to flat/low exposure.
+
+## What backtesting.py would add
+- **Vectorized historical replay:** backtesting.py provides fast bar-by-bar playback with built-in equity tracking. It would give us deterministic offline rollouts using our prepared candle/intrinsic-time datasets without standing up the simulated execution layer when exchange realism is unnecessary.
+- **Indicator/strategy hooks:** Strategies in backtesting.py can call our feature generators directly, letting us validate that feature pipelines (ATR/RSI/Bollinger/imbalance/volatility clusters) actually lift Sharpe under simple rules before training RL.
+- **Charting and diagnostics:** The library includes equity/position visualizations that could complement our logging-only A3C loop. This improves explainability for model audits and hyperparameter sweeps.
+
+## Integration path
+1. **Environment adapter:** Implement a thin adapter that exposes a backtesting.py `Strategy` or vectorized runner as a gym-like environment (reset/step), feeding observations shaped like our A3C expects (batch-first float tensors). Map fills/slippage either to the existing simulated retail rules or to backtesting.py’s built-ins depending on mode.
+2. **Execution realism toggle:** Keep the current `SimulatedRetailExecutionEnv` for slippage/FIFO realism, but add a `BacktestingEnv` for deterministic historical replay. Use the existing `env_factory` hook in `A3CAgent` to choose between them at runtime.
+3. **Risk manager integration:** Wrap backtesting actions through `RiskManager.apply_classification_logits` or `apply_regression_output` before submitting to the adapter. Log gate reasons to align offline backtests with live risk posture.
+4. **Data source:** Reuse prepared datasets (including intrinsic-time bars) as the price feed for backtesting.py. Ensure spread/commission normalization is applied consistently so reward magnitudes match those assumed by the retail simulator.
+
+## Security and safety notes
+- **Deterministic seeds:** When using backtesting.py, keep RNG seeds and data windows fixed inside the adapter so results are reproducible and resistant to tampering. The current A3C harness already guards against malformed env returns; keep similar checks in the adapter.
+- **No credential exposure:** backtesting.py runs offline; avoid mixing it with MetaApi/live connectors in the same process to prevent accidental leakage of auth tokens in logs. Maintain separate config paths for live vs. offline runs.
+- **Action validation:** Mirror the normalization in `OrderAction.normalized` (size rounding, side/action checks) inside the adapter to avoid accepting malformed or adversarial actions from experimental policies.
+
+## Starting-equity considerations
+- **Simulated retail env baseline:** The `SimulatedRetailExecutionEnv` now seeds cash from `ExecutionConfig.initial_cash`, which defaults to **$50,000** to mirror the demonstration funding level. Positions still start flat unless you preload inventory. Portfolio equity therefore begins at the configured bankroll and evolves with trading performance.
+- **How to target a specific starting equity:** Override `ExecutionConfig(initial_cash=...)` (and optionally add an `initial_inventory` hook if you need preloaded positions) so `reset` initializes cash to your chosen bankroll. Backtesting.py adapters should mirror the same initial cash/inventory so offline equity curves match the simulated retail setup.

--- a/execution/simulated_retail_env.py
+++ b/execution/simulated_retail_env.py
@@ -55,6 +55,7 @@ class ExecutionConfig:
     """Configuration for the simulated retail execution environment."""
 
     initial_mid_price: float = 100.0
+    initial_cash: float = 50_000.0
     spread: float = 0.02  # dollars
     price_drift: float = 0.0
     price_volatility: float = 0.05
@@ -78,6 +79,8 @@ class ExecutionConfig:
             raise ValueError("Lot size must be positive")
         if self.price_volatility < 0:
             raise ValueError("Price volatility must be non-negative")
+        if self.initial_cash < 0:
+            raise ValueError("Initial cash must be non-negative")
 
 
 @dataclass
@@ -171,7 +174,7 @@ class SimulatedRetailExecutionEnv:
 
         self.step_count = 0
         self.mid_price = self.config.initial_mid_price
-        self.cash = 0.0
+        self.cash = self.config.initial_cash
         self.realized_pnl = 0.0
         self.inventory = 0.0
         self._slippage_paid = 0.0
@@ -186,7 +189,7 @@ class SimulatedRetailExecutionEnv:
         self.positions.clear()
         self.step_count = 0
         self.mid_price = self.config.initial_mid_price
-        self.cash = 0.0
+        self.cash = self.config.initial_cash
         self.realized_pnl = 0.0
         self.inventory = 0.0
         self._slippage_paid = 0.0


### PR DESCRIPTION
## Summary
- add an `initial_cash` field to `ExecutionConfig` with a default $50,000 demo balance and validate it
- initialize the simulated retail environment cash from configuration on construction and reset
- document the 50k baseline and how to override starting equity for backtesting or training

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c8f8aa98832eb662cf3d072ae853)