### PR TITLE
Add Hugging Face mirrors for GDELT downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This repository trains and evaluates a foreign-exchange forecasting model on min
 3) Train and test:
    - Train: `python utils/run_training_pipeline.py --pairs gbpusd --t-in 120 --t-out 10 --epochs 3`
    - Test: `python eval/run_evaluation.py --pairs gbpusd --checkpoint-path models/gbpusd_best_model.pt`
-4) Optional sentiment: add `--run-gdelt-download` to pull GDELT GKG files before training. [Leetaru & Schrodt 2013]
+4) Optional sentiment: add `--run-gdelt-download` to pull GDELT GKG files before training. If the primary endpoint is flaky,
+   pass a Hugging Face mirror (e.g., `--gdelt-mirror hf-maxlong-2022`, `hf-olm`, or `hf-andreas-helgesson`) or a custom
+   HTTPS URL via `--gdelt-base-url`. [Leetaru & Schrodt 2013]
 5) Optional mini-game: when prompted during training, press `y` to launch; quit with `Q` (may slow training).
 
 ### Intrinsic-time bars (directional-change)

--- a/utils/run_training_pipeline.py
+++ b/utils/run_training_pipeline.py
@@ -130,6 +130,19 @@ def parse_args() -> argparse.Namespace:
         default="daily",
         help="GDELT download cadence.",
     )
+    parser.add_argument(
+        "--gdelt-mirror",
+        default="gdelt",
+        help=(
+            "Mirror to use for GDELT downloads (gdelt, hf-maxlong-2022, hf-olm, hf-andreas-helgesson). "
+            "Use a Hugging Face mirror if the primary endpoint returns errors."
+        ),
+    )
+    parser.add_argument(
+        "--gdelt-base-url",
+        default=None,
+        help="Override the GDELT download base URL (https:// only). Takes precedence over --gdelt-mirror.",
+    )
     parser.add_argument("--gdelt-step-minutes", type=int, default=15, help="Cadence for 15min resolution.")
     parser.add_argument("--gdelt-out-dir", default="data/gdelt", help="Destination folder for GDELT zips.")
     parser.add_argument("--gdelt-overwrite", action="store_true", help="Re-download even if files exist.")
@@ -360,6 +373,8 @@ def run_gdelt_download(args) -> None:
         end_date,
         "--resolution",
         args.gdelt_resolution,
+        "--mirror",
+        args.gdelt_mirror,
         "--step-minutes",
         str(args.gdelt_step_minutes),
         "--out-dir",
@@ -373,6 +388,8 @@ def run_gdelt_download(args) -> None:
     ]
     if args.gdelt_overwrite:
         cmd.append("--overwrite")
+    if args.gdelt_base_url:
+        cmd.extend(["--base-url", args.gdelt_base_url])
     print(
         f"[info] Downloading GDELT to {args.gdelt_out_dir} "
         f"({args.gdelt_resolution}, {args.gdelt_start_date} -> {end_date})"


### PR DESCRIPTION
## Summary
- add predefined Hugging Face mirrors and TLS-only override support to the GDELT downloader
- expose mirror/base URL options in the training pipeline CLI so downloads can target mirror datasets
- document how to use mirror flags when the primary GDELT endpoint is unavailable

## Testing
- `python -m pytest tests/test_smoke.py` *(fails: missing torch dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a5ddda1ec832eb62a6209d8222ce6)