### PR TITLE
Default align_candle_to_regime to configured bucket size

### DIFF
--- a/gdelt/alignment.py
+++ b/gdelt/alignment.py
@@ -6,8 +6,22 @@ from datetime import datetime, timedelta, timezone
 from gdelt.config import GDELT_TIME_DELTA_MINUTES
 
 
-def align_candle_to_regime(candle_time: datetime, bucket_minutes: int = 60) -> datetime:
-    """Floor candle_time to the previous full regime bucket (default: hourly)."""
+def get_gdelt_bucket_minutes() -> int:
+    """Return the default GDELT bucket size in minutes from configuration."""
+    return GDELT_TIME_DELTA_MINUTES
+
+
+def align_candle_to_regime(
+    candle_time: datetime, bucket_minutes: int | None = None
+) -> datetime:
+    """Floor candle_time to the previous full regime bucket using the configured default.
+
+    When ``bucket_minutes`` is not provided, the interval from ``config.py``
+    (``GDELT_TIME_DELTA_MINUTES``, currently 15 minutes) is used so aligners
+    and iterators remain consistent.
+    """
+    if bucket_minutes is None:
+        bucket_minutes = get_gdelt_bucket_minutes()
     candle_time = candle_time.astimezone(timezone.utc)
     minutes = (candle_time.minute // bucket_minutes) * bucket_minutes
     aligned = candle_time.replace(minute=0, second=0, microsecond=0) + timedelta(minutes=minutes)
@@ -17,14 +31,14 @@ def align_candle_to_regime(candle_time: datetime, bucket_minutes: int = 60) -> d
 
 
 def iter_gdelt_buckets(start: datetime, end: datetime) -> list[datetime]:
-    """Generate regime bucket start times between start and end inclusive."""
+    """Generate regime bucket start times between start and end inclusive using the configured bucket size."""
     start = start.astimezone(timezone.utc)
     end = end.astimezone(timezone.utc)
     if end < start:
         raise ValueError("end must be after start")
     buckets = []
-    current = align_candle_to_regime(start, bucket_minutes=GDELT_TIME_DELTA_MINUTES)
+    current = align_candle_to_regime(start, bucket_minutes=get_gdelt_bucket_minutes())
     while current <= end:
         buckets.append(current)
-        current += timedelta(minutes=GDELT_TIME_DELTA_MINUTES)
+        current += timedelta(minutes=get_gdelt_bucket_minutes())
     return buckets

--- a/tests/test_gdelt_alignment.py
+++ b/tests/test_gdelt_alignment.py
@@ -1,0 +1,55 @@
+"""Tests for GDELT alignment utilities."""
+from datetime import datetime, timezone
+from importlib import util
+from pathlib import Path
+import sys
+import types
+
+def _load_config_module():
+    config_path = Path(__file__).resolve().parents[1] / "gdelt" / "config.py"
+    spec = util.spec_from_file_location("gdelt.config", config_path)
+    assert spec and spec.loader
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules[spec.name] = module
+    return module
+
+
+def _load_alignment_module():
+    if "gdelt" not in sys.modules:
+        gdelt_module = types.ModuleType("gdelt")
+        gdelt_module.__path__ = [str(Path(__file__).resolve().parents[1] / "gdelt")]
+        sys.modules["gdelt"] = gdelt_module
+    _load_config_module()
+    alignment_path = Path(__file__).resolve().parents[1] / "gdelt" / "alignment.py"
+    spec = util.spec_from_file_location("gdelt.alignment", alignment_path)
+    assert spec and spec.loader
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_align_defaults_to_config_bucket_minutes() -> None:
+    alignment = _load_alignment_module()
+    config = _load_config_module()
+    ts = datetime(2024, 1, 1, 0, 23, tzinfo=timezone.utc)
+
+    aligned = alignment.align_candle_to_regime(ts)
+
+    assert aligned == datetime(2024, 1, 1, 0, 15, tzinfo=timezone.utc)
+    assert alignment.get_gdelt_bucket_minutes() == config.GDELT_TIME_DELTA_MINUTES
+
+
+def test_iter_gdelt_buckets_respects_configured_bucket_size() -> None:
+    alignment = _load_alignment_module()
+    start = datetime(2024, 1, 1, 0, 7, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 1, 0, 52, tzinfo=timezone.utc)
+
+    buckets = alignment.iter_gdelt_buckets(start, end)
+
+    assert buckets == [
+        datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+        datetime(2024, 1, 1, 0, 15, tzinfo=timezone.utc),
+        datetime(2024, 1, 1, 0, 30, tzinfo=timezone.utc),
+        datetime(2024, 1, 1, 0, 45, tzinfo=timezone.utc),
+    ]


### PR DESCRIPTION
## Summary
- add helper to derive the GDELT bucket interval from configuration and use it as the default for regime alignment
- update bucket iteration to share the configured interval and clarify docstrings
- add alignment tests covering the configured default bucket size behavior

## Testing
- pytest tests/test_gdelt_alignment.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b24e01c88832ea7d65247de67d072)