### PR TITLE
Clean up duplicate file headers

### DIFF
--- a/gdelt/parser.py
+++ b/gdelt/parser.py
@@ -2,10 +2,6 @@
 from __future__ import annotations
 
 import csv
-"""Stream parser for GDELT GKG files."""
-from __future__ import annotations
-
-import csv
 import gzip
 from dataclasses import dataclass
 from datetime import datetime, timezone

--- a/models/agent_regime_hybrid.py
+++ b/models/agent_regime_hybrid.py
@@ -1,5 +1,4 @@
 """Regime-aware hybrid model combining price and GDELT encoders."""
-"""Regime-aware hybrid encoder/decoder stack for price + GDELT fusion."""
 from __future__ import annotations
 
 import torch


### PR DESCRIPTION
## Summary
- remove duplicate docstring and import blocks at the tops of `gdelt/parser.py` and `models/agent_regime_hybrid.py`
- keep a single clear module docstring in each file

## Testing
- ruff check gdelt/parser.py models/agent_regime_hybrid.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b25cc5f34832e88e86e805a389a71)