### PR TITLE
Add zip handling to GDELT parser

### DIFF
--- a/gdelt/parser.py
+++ b/gdelt/parser.py
@@ -2,15 +2,13 @@
 from __future__ import annotations
 
 import csv
-"""Stream parser for GDELT GKG files."""
-from __future__ import annotations
-
-import csv
 import gzip
+import io
+import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Iterable, Iterator, List, Optional
+from typing import Dict, Iterable, Iterator, List, Optional, TextIO
 
 
 @dataclass
@@ -63,30 +61,59 @@ class GDELTParser:
     IDX_GCAM = 15
 
     def parse_file(self, path: Path) -> Iterator[GDELTRecord]:
-        opener = gzip.open if path.suffix == ".gz" else open
+        suffix = path.suffix.lower()
+
+        if suffix == ".zip":
+            yield from self._parse_zip(path)
+            return
+
+        opener = gzip.open if suffix == ".gz" else open
         with opener(path, "rt", encoding="utf-8", errors="ignore") as f:
-            reader = csv.reader(f, delimiter="\t")
-            for row in reader:
-                if len(row) <= self.IDX_TONE:
-                    continue
-                dt = self._parse_datetime(row[self.IDX_DATE])
-                themes = self._parse_themes(row[self.IDX_THEMES], row[self.IDX_ENHANCED_THEMES])
-                counts = self._parse_counts(row[self.IDX_COUNTS])
-                tone = self._parse_tone(row[self.IDX_TONE])
-                persons = self._parse_list(row[self.IDX_PERSONS])
-                orgs = self._parse_list(row[self.IDX_ORGS])
-                locations = self._parse_locations(row[self.IDX_LOCATIONS])
-                gcam = self._parse_gcam(row[self.IDX_GCAM]) if len(row) > self.IDX_GCAM else {}
-                yield GDELTRecord(
-                    datetime=dt,
-                    themes=themes,
-                    counts=counts,
-                    tone=tone,
-                    persons=persons,
-                    orgs=orgs,
-                    locations=locations,
-                    gcam=gcam,
-                )
+            yield from self._parse_reader(f)
+
+    def _parse_zip(self, path: Path) -> Iterator[GDELTRecord]:
+        with zipfile.ZipFile(path) as archive:
+            member = self._select_zip_member(archive)
+            if member is None:
+                raise ValueError(f"No CSV files found inside {path}")
+
+            with archive.open(member) as raw_file:
+                with io.TextIOWrapper(raw_file, encoding="utf-8", errors="ignore") as text_file:
+                    yield from self._parse_reader(text_file)
+
+    def _select_zip_member(self, archive: zipfile.ZipFile) -> Optional[str]:
+        names = archive.namelist()
+        for name in names:
+            if name.lower().endswith(".gkgv2.csv"):
+                return name
+        for name in names:
+            if name.lower().endswith(".csv"):
+                return name
+        return None
+
+    def _parse_reader(self, file_obj: TextIO) -> Iterator[GDELTRecord]:
+        reader = csv.reader(file_obj, delimiter="\t")
+        for row in reader:
+            if len(row) <= self.IDX_TONE:
+                continue
+            dt = self._parse_datetime(row[self.IDX_DATE])
+            themes = self._parse_themes(row[self.IDX_THEMES], row[self.IDX_ENHANCED_THEMES])
+            counts = self._parse_counts(row[self.IDX_COUNTS])
+            tone = self._parse_tone(row[self.IDX_TONE])
+            persons = self._parse_list(row[self.IDX_PERSONS])
+            orgs = self._parse_list(row[self.IDX_ORGS])
+            locations = self._parse_locations(row[self.IDX_LOCATIONS])
+            gcam = self._parse_gcam(row[self.IDX_GCAM]) if len(row) > self.IDX_GCAM else {}
+            yield GDELTRecord(
+                datetime=dt,
+                themes=themes,
+                counts=counts,
+                tone=tone,
+                persons=persons,
+                orgs=orgs,
+                locations=locations,
+                gcam=gcam,
+            )
 
     @staticmethod
     def _parse_datetime(value: str) -> datetime:

--- a/tests/test_gdelt_parser.py
+++ b/tests/test_gdelt_parser.py
@@ -1,0 +1,63 @@
+import csv
+import importlib.util
+import sys
+import zipfile
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PARSER_PATH = PROJECT_ROOT / "gdelt" / "parser.py"
+
+spec = importlib.util.spec_from_file_location("gdelt_parser", PARSER_PATH)
+assert spec and spec.loader
+gdelt_parser = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = gdelt_parser
+spec.loader.exec_module(gdelt_parser)
+GDELTParser = gdelt_parser.GDELTParser
+
+
+def _build_sample_zip(tmp_path: Path) -> Path:
+    data_row = [
+        "0",
+        "20240101000000",
+        "",
+        "",
+        "",
+        "CountType#1.0",
+        "THEME1;THEME2",
+        "ENHTHEME#detail",
+        "LOC#Name#0#USA#10#20",
+        "Person1;Person2",
+        "Org1;Org2",
+        "0.1,0.2,0.3,0.4,0.5",
+        "",
+        "",
+        "",
+        "c1:1.5,c2:2.5",
+    ]
+
+    csv_path = tmp_path / "sample.gkgv2.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f, delimiter="\t")
+        writer.writerow(data_row)
+
+    zip_path = tmp_path / "sample.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.write(csv_path, arcname=csv_path.name)
+
+    return zip_path
+
+
+def test_parse_zip_file(tmp_path: Path):
+    zip_path = _build_sample_zip(tmp_path)
+    parser = GDELTParser()
+
+    records = list(parser.parse_file(zip_path))
+
+    assert len(records) == 1
+    record = records[0]
+    assert record.datetime.year == 2024
+    assert record.themes == ["ENHTHEME", "THEME1", "THEME2"]
+    assert record.counts[0].type == "CountType"
+    assert record.counts[0].value == 1.0
+    assert record.locations[0].country_code == "USA"
+    assert record.gcam == {"c1": 1.5, "c2": 2.5}


### PR DESCRIPTION
## Summary
- add zip support to GDELT parser including selection of gkgv2 or first CSV member
- refactor parsing to reuse a shared reader pipeline and preserve gz/plain handling
- add fixture-based smoke test to validate parsing from a zipped sample

## Testing
- pytest tests/test_gdelt_parser.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b266847e0832e8434297603d16709)