### PR TITLE
Fix dataset features and training/evaluation runners

### DIFF
--- a/data/prepare_dataset.py
+++ b/data/prepare_dataset.py
@@ -165,7 +165,6 @@ def process_pair(pair: str, args, batch_size: Optional[int] = None):
         include_groups=include_groups,
         exclude_groups=exclude_groups,
     )
-    feature_df = build_feature_frame(raw_df, config=feature_cfg)
     df_for_features = raw_df
     if args.intrinsic_time:
         df_for_features = build_intrinsic_time_bars(
@@ -178,7 +177,7 @@ def process_pair(pair: str, args, batch_size: Optional[int] = None):
             f"DC thresholds up={args.dc_threshold_up}, down={args.dc_threshold_down or args.dc_threshold_up}"
         )
 
-    feature_df = build_feature_frame(df_for_features)
+    feature_df = build_feature_frame(df_for_features, config=feature_cfg)
     feature_df["datetime"] = pd.to_datetime(feature_df["datetime"])
 
     train_range, val_range, test_range = _compute_time_ranges(

--- a/eval/run_evaluation.py
+++ b/eval/run_evaluation.py
@@ -25,6 +25,7 @@ from data.prepare_dataset import process_pair
 from eval.agent_eval import evaluate_model, evaluate_policy_agent
 from models.agent_hybrid import build_model
 from models.signal_policy import SignalModel, SignalPolicyAgent
+from risk.risk_manager import RiskManager
 
 
 def parse_args():

--- a/train/run_training.py
+++ b/train/run_training.py
@@ -54,6 +54,11 @@ def parse_args():
     parser.add_argument("--weight-decay", type=float, default=0.0)
     parser.add_argument("--device", default="cuda")
     parser.add_argument("--checkpoint-path", default="models/best_model.pt")
+    parser.add_argument(
+        "--disable-risk",
+        action="store_true",
+        help="Disable risk manager gating during signal pretraining.",
+    )
     parser.add_argument("--max-return-weight", type=float, default=1.0)
     parser.add_argument("--topk-return-weight", type=float, default=1.0)
     parser.add_argument("--topk-price-weight", type=float, default=1.0)
@@ -124,14 +129,13 @@ def main():
             learning_rate=args.learning_rate,
             weight_decay=args.weight_decay,
             device=device,
-            checkpoint_path=str(ckpt_path),
             max_return_weight=args.max_return_weight,
             topk_return_weight=args.topk_return_weight,
             topk_price_weight=args.topk_price_weight,
             sell_now_weight=args.sell_now_weight,
             checkpoint_path=str(signal_ckpt),
         )
-        train_cfg.risk.enabled = not args.disable_risk
+        pretrain_cfg.risk.enabled = not args.disable_risk
 
         signal_model = SignalModel(signal_cfg)
         signal_history = pretrain_signal_model(


### PR DESCRIPTION
## Summary
- ensure dataset preparation builds features once using the configured FeatureConfig and intrinsic-time inputs
- repair signal training runner by wiring risk toggle, removing undefined checkpoint path, and exposing the flag via CLI
- import the risk manager in the evaluation CLI to avoid a runtime NameError when gating policies

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b2bf22a10832ea2e6519bc4f6609d)