### PR TITLE
Rename hybrid model to Dignity

### DIFF
--- a/docs/backtesting_rl_analysis.md
+++ b/docs/backtesting_rl_analysis.md
@@ -1,8 +1,8 @@
 # Backtesting.py fit vs existing RL and execution stack
 
 ## Current RL and execution capabilities
-- **A3C harness:** Multi-worker actor-critic training already wraps the hybrid CNN–LSTM–attention encoder. It handles asynchronous rollouts, shared Adam optimizer state, and gradient synchronization with value/policy losses plus entropy regularization. The harness expects a gym-like environment factory, so any backtesting-driven env would plug in via the existing factory hook.
-- **Hybrid feature encoder inside RL:** The RL stack reuses the ModelConfig-driven hybrid encoder (LSTM + Conv1d + attention) as a shared feature extractor before policy/value heads. This keeps RL aligned with the forecasting backbone but currently assumes fixed feature counts and time-major tensors from the data agent.
+- **A3C harness:** Multi-worker actor-critic training already wraps the Dignity CNN–LSTM–attention encoder. It handles asynchronous rollouts, shared Adam optimizer state, and gradient synchronization with value/policy losses plus entropy regularization. The harness expects a gym-like environment factory, so any backtesting-driven env would plug in via the existing factory hook.
+- **Dignity feature encoder inside RL:** The RL stack reuses the ModelConfig-driven Dignity encoder (LSTM + Conv1d + attention) as a shared feature extractor before policy/value heads. This keeps RL aligned with the forecasting backbone but currently assumes fixed feature counts and time-major tensors from the data agent.
 - **Retail execution simulator:** A gym-like execution environment exists with spread, slippage, limit-fill probability, decision lag, FIFO PnL, and logging. Rewards are portfolio value deltas, making it suitable for policy evaluation without exchange dependencies.
 - **Risk gating:** A risk manager throttles logits or regression outputs when drawdown, volatility, spread, or no-trade windows are hit. This can be used during backtests to mimic live guardrails by clamping actions to flat/low exposure.
 

--- a/eval/agent_eval.py
+++ b/eval/agent_eval.py
@@ -4,13 +4,13 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
-from models.agent_hybrid import HybridCNNLSTMAttention
+from models.agent_hybrid import DignityModel
 from models.signal_policy import SignalPolicyAgent
 from risk.risk_manager import RiskManager
 
 
 def _collect_outputs(
-    model: HybridCNNLSTMAttention,
+    model: DignityModel,
     loader: DataLoader,
     device: torch.device,
     risk_manager: RiskManager | None = None,
@@ -83,7 +83,7 @@ def regression_metrics(preds: np.ndarray, targets: np.ndarray) -> Dict[str, floa
 
 
 def evaluate_model(
-    model: HybridCNNLSTMAttention,
+    model: DignityModel,
     loader: DataLoader,
     task_type: str = "classification",
     risk_manager: RiskManager | None = None,

--- a/export/agent_export.py
+++ b/export/agent_export.py
@@ -1,12 +1,12 @@
 import torch
 
 from config.config import ExportConfig
-from models.agent_hybrid import HybridCNNLSTMAttention
+from models.agent_hybrid import DignityModel
 from models.signal_policy import SignalPolicyAgent
 
 
 def export_to_onnx(
-    model: HybridCNNLSTMAttention,
+    model: DignityModel,
     export_cfg: ExportConfig,
     example_input: torch.Tensor,
     task_type: str = "classification",

--- a/models/agent_hybrid.py
+++ b/models/agent_hybrid.py
@@ -62,9 +62,9 @@ class PriceSequenceEncoder(nn.Module):
         return context, attn_weights
 
 
-class HybridCNNLSTMAttention(nn.Module):
+class DignityModel(nn.Module):
     """
-    CNN + BiLSTM + temporal attention hybrid model with multi-head outputs.
+    CNN + BiLSTM + temporal attention Dignity model with multi-head outputs.
     """
 
     def __init__(self, cfg: ModelConfig, task_type: str = "classification"):
@@ -109,11 +109,15 @@ def build_model(
     num_dir_classes: int | None = None,
     num_volatility_classes: int | None = None,
     return_dim: int | None = None,
-) -> HybridCNNLSTMAttention:
+) -> DignityModel:
     if num_dir_classes is not None:
         cfg.num_dir_classes = num_dir_classes
     if num_volatility_classes is not None:
         cfg.num_volatility_classes = num_volatility_classes
     if return_dim is not None:
         cfg.return_dim = return_dim
-    return HybridCNNLSTMAttention(cfg, task_type=task_type)
+    return DignityModel(cfg, task_type=task_type)
+
+
+# Backward compatibility for existing checkpoints/imports.
+HybridCNNLSTMAttention = DignityModel

--- a/run/infer.py
+++ b/run/infer.py
@@ -1,7 +1,7 @@
-"""Run hybrid encoder + policy inference against a simulator or MetaApi.
+"""Run Dignity encoder + policy inference against a simulator or MetaApi.
 
 This runner builds features from candle data (plus optional intrinsic bars),
-loads the hybrid CNN-LSTM-attention encoder, and routes actions through an
+loads the Dignity CNN-LSTM-attention encoder, and routes actions through an
 execution backend selected at runtime. The same inference path is shared across
 simulation and live modes through dependency injection.
 """
@@ -25,7 +25,7 @@ if str(ROOT) not in sys.path:
 
 from config.config import ModelConfig  # noqa: E402
 from features.agent_features import build_feature_frame  # noqa: E402
-from models.agent_hybrid import HybridCNNLSTMAttention, build_model  # noqa: E402
+from models.agent_hybrid import DignityModel, build_model  # noqa: E402
 
 
 ACTION_NAMES = ["sell", "hold", "buy"]
@@ -148,7 +148,7 @@ def build_state(cfg: InferenceConfig) -> tuple[torch.Tensor, float, List[str]]:
     return state_tensor, latest_price, feature_cols
 
 
-def load_policy(cfg: InferenceConfig, num_features: int) -> HybridCNNLSTMAttention:
+def load_policy(cfg: InferenceConfig, num_features: int) -> DignityModel:
     model_cfg = ModelConfig(num_features=num_features)
     model = build_model(model_cfg, task_type=cfg.task_type)
     checkpoint = torch.load(cfg.checkpoint_path, map_location=cfg.device)
@@ -165,7 +165,7 @@ def telemetry_log(logger: logging.Logger, message: str, payload: Dict[str, objec
 
 
 class InferenceRunner:
-    def __init__(self, model: HybridCNNLSTMAttention, backend: ExecutionBackend, device: str):
+    def __init__(self, model: DignityModel, backend: ExecutionBackend, device: str):
         self.model = model
         self.backend = backend
         self.device = device
@@ -190,7 +190,7 @@ class InferenceRunner:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Hybrid encoder + policy inference runner")
+    parser = argparse.ArgumentParser(description="Dignity encoder + policy inference runner")
     parser.add_argument("--candles", required=True, type=Path, help="CSV with OHLC candles including datetime")
     parser.add_argument("--intrinsic-bars", type=Path, help="Optional CSV of intrinsic features to append")
     parser.add_argument("--checkpoint", required=True, type=Path, help="Path to model checkpoint")

--- a/train/agent_train.py
+++ b/train/agent_train.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
 from config.config import RLTrainingConfig, TrainingConfig
-from models.agent_hybrid import HybridCNNLSTMAttention
+from models.agent_hybrid import DignityModel
 from models.signal_policy import ExecutionPolicy, SignalModel
 from risk.risk_manager import RiskManager
 
@@ -85,7 +85,7 @@ def _compute_losses(
 
 
 def _evaluate(
-    model: HybridCNNLSTMAttention,
+    model: DignityModel,
     loader: DataLoader,
     cfg: TrainingConfig,
     device,
@@ -126,7 +126,7 @@ def _evaluate(
 
 
 def train_model(
-    model: HybridCNNLSTMAttention,
+    model: DignityModel,
     train_loader: DataLoader,
     val_loader: DataLoader,
     cfg: TrainingConfig,


### PR DESCRIPTION
## Summary
- rename the hybrid CNN-LSTM-attention model class to `DignityModel` and update the factory annotation
- switch training, evaluation, export, and inference runners to the new name while keeping a backward-compatible alias
- refresh documentation and CLI descriptions to refer to the Dignity model identity

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b2e46b3b8832e95bf4c0117e5a814)