### PR TITLE
Fix feature frame build for intrinsic time

### DIFF
--- a/data/prepare_dataset.py
+++ b/data/prepare_dataset.py
@@ -165,20 +165,19 @@ def process_pair(pair: str, args, batch_size: Optional[int] = None):
         include_groups=include_groups,
         exclude_groups=exclude_groups,
     )
-    feature_df = build_feature_frame(raw_df, config=feature_cfg)
     df_for_features = raw_df
     if args.intrinsic_time:
         df_for_features = build_intrinsic_time_bars(
             raw_df,
             up_threshold=args.dc_threshold_up,
-            down_threshold=args.dc_threshold_down,
+            down_threshold=args.dc_threshold_down or args.dc_threshold_up,
         )
         print(
             f"[intrinsic] reduced {len(raw_df):,} -> {len(df_for_features):,} bars using "
             f"DC thresholds up={args.dc_threshold_up}, down={args.dc_threshold_down or args.dc_threshold_up}"
         )
 
-    feature_df = build_feature_frame(df_for_features)
+    feature_df = build_feature_frame(df_for_features, config=feature_cfg)
     feature_df["datetime"] = pd.to_datetime(feature_df["datetime"])
 
     train_range, val_range, test_range = _compute_time_ranges(


### PR DESCRIPTION
## Summary
- build features once using the intrinsic-time-adjusted frame when enabled
- pass the CLI-derived FeatureConfig into feature extraction and default the directional change down threshold

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b2ce748b4832ea9a97f27404eaabd)